### PR TITLE
Update mesh.ini.example with MQTT instructions

### DIFF
--- a/mesh.ini.example
+++ b/mesh.ini.example
@@ -99,6 +99,7 @@ Admin = !deadbeef
 # en: Meshtastic device file. For TCP connections prepend with tcp:, e.g. tcp:meshtastic.local or tcp:1.2.3.4. Works on Linux, OSX and possibly some Unix flavors. String.
 # pl: Plik urządzenia Meshtastic. W przypadku połączeń TCP poprzedź tcp:, np. tcp:meshtastic.local lub tcp:1.2.3.4. Działa na systemach Linux, OSX i prawdopodobnie na niektórych wersjach systemu Unix. Strunowy.
 # pt: Arquivo de dispositivo Meshtastic. Para conexões TCP, inclua tcp:, por exemplo tcp:meshtastic.local ou tcp:1.2.3.4. Funciona no Linux, OSX e possivelmente em alguns tipos de Unix. Fragmento. 
+# en: Enable MQTT globally in the end of this file and for virtual node emulation use the following: Device = mqtt
 Device = /dev/ttyACM0
 # en: Local database file name. String.
 # pl: Nazwa pliku lokalnej bazy danych. Strunowy.


### PR DESCRIPTION
Added instruction for enabling MQTT globally and virtual node emulation.